### PR TITLE
Fixes token expiry issues

### DIFF
--- a/Api/Entities/OAuthToken.cs
+++ b/Api/Entities/OAuthToken.cs
@@ -8,6 +8,8 @@ namespace KoenZomers.Ring.Api.Entities
     /// </summary>
     public class OAutToken
     {
+        private DateTime _expiresAt;
+
         /// <summary>
         /// The OAuth access token that can be used as a Bearer token to communicate with the Ring API
         /// </summary>
@@ -17,7 +19,19 @@ namespace KoenZomers.Ring.Api.Entities
         /// <summary>
         /// Gets a DateTime with when this token expires
         /// </summary>
-        public DateTime ExpiresAt { get; private set; }
+        public DateTime ExpiresAt
+        {
+            get { return _expiresAt; }
+            // Sets token expiry datetime
+            set { _expiresAt = value; }
+        }
+
+        [JsonPropertyName("expires_in")]
+        public int ExpiresIn
+        {
+            // Calculate and set token expiry date
+            set { ExpiresAt = DateTime.UtcNow.AddSeconds(value); }
+        }
 
         /// <summary>
         /// The OAuth Refresh Token that can be used to get a new OAuth Access Token after it expires

--- a/Api/Session.cs
+++ b/Api/Session.cs
@@ -282,7 +282,7 @@ namespace KoenZomers.Ring.Api
             }
 
             // Ensure the access token in the session is still valid
-            if (OAuthToken.ExpiresAt < DateTime.Now)
+            if (OAuthToken.ExpiresAt <= DateTime.Now)
             {
                 // Access token is no longer valid, check if we have a refresh token available to refresh the session
                 if (string.IsNullOrEmpty(OAuthToken.RefreshToken))


### PR DESCRIPTION
The logic that checks for token expiry was not using a valid datetime since the assignment is broken in the OAuthToken implementation.
After getting a token response from the auth endpoint, the program was never setting the expiry date to the OAuthToken class, so any check for token expiry would always return true.

As a result, any calls to the `EnsureSessionValid()` method triggered a token refresh for each video download, causing the API to eventually throw a "too many token requests" error.

This PR adds a new property in the OAuthToken class to store the actual expiry date as provided by the auth API when the request for a token is made. This enables expiry validation to return accurate results.

Closes #17 