### PR TITLE
Fixes bug when calculating expiration of token

### DIFF
--- a/.github/workflows/draftnewrelease.yml
+++ b/.github/workflows/draftnewrelease.yml
@@ -22,7 +22,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
       with:
         tag_name: ${{ github.ref }}
-        release_name: Version 3.1.1.0
+        release_name: Version 3.2.0.0
         body: |
           - First Change
           - Second Change

--- a/Api/Entities/OAuthToken.cs
+++ b/Api/Entities/OAuthToken.cs
@@ -8,11 +8,23 @@ namespace KoenZomers.Ring.Api.Entities
     /// </summary>
     public class OAutToken
     {
+        private int _expiresInSeconds;
+
         /// <summary>
         /// The OAuth access token that can be used as a Bearer token to communicate with the Ring API
         /// </summary>
         [JsonPropertyName("access_token")]
         public string AccessToken { get; set; }
+
+        /// <summary>
+        /// Gets the amount of seconds after creation of this OAuth token after which it expires
+        /// </summary>
+        [JsonPropertyName("expires_in")]
+        public int ExpiresInSeconds
+        {
+            get { return _expiresInSeconds; }
+            set { _expiresInSeconds = value; ExpiresAt = DateTime.Now.AddSeconds(value); }
+        }
 
         /// <summary>
         /// Gets a DateTime with when this token expires

--- a/AssemblyInfo.cs
+++ b/AssemblyInfo.cs
@@ -10,4 +10,4 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("Debug")]
 [assembly: AssemblyCopyright("Koen Zomers")]
 [assembly: AssemblyMetadata("RepositoryUrl", "https://github.com/KoenZomers/RingRecordingDownload")]
-[assembly: AssemblyVersion("3.1.1.0")]
+[assembly: AssemblyVersion("3.2.0.0")]

--- a/ConsoleAppCore/ConsoleAppCore.csproj
+++ b/ConsoleAppCore/ConsoleAppCore.csproj
@@ -7,7 +7,7 @@
     <AssemblyName>RingRecordingDownload</AssemblyName>
     <PackageId>KoenZomers.Ring.RecordingDownload</PackageId>
     <Authors>Koen Zomers</Authors>
-    <Version>3.1.1.0</Version>
+    <Version>3.2.0.0</Version>
     <Product>Ring Recording Download</Product>
     <Description>Allows downloading of recordings from Ring devices from the Ring cloud to your local machine</Description>
     <Copyright>Koen Zomers</Copyright>
@@ -41,6 +41,12 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Api\Api.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="App.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/ConsoleAppCore/ConsoleAppCore.csproj
+++ b/ConsoleAppCore/ConsoleAppCore.csproj
@@ -43,10 +43,4 @@
     <ProjectReference Include="..\Api\Api.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <None Update="App.config">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-
 </Project>

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Console application written in .NET 6 compiled for Windows, Raspberry Pi, Linux 
 
 ## Version History
 
+[3.2.0.0](https://github.com/KoenZomers/RingRecordingDownload/releases/tag/3.2.0.0) - July 26, 2024
+
+- Fixes Token Expiration logic that throws session errors after the token expires.
+
 [3.1.1.0](https://github.com/KoenZomers/RingRecordingDownload/releases/tag/3.1.1.0) - April 7, 2024
 
 - Fixed typo in console application


### PR DESCRIPTION
ExpiresAt wasn't being set properly, so the refresh condition was never met and it would always throw an exception, there's a PR already fixing this but the contributor hasn't replied to the comments since april, this change addresses the requested changes.