### PR TITLE
Bugfix for tokens that become unauthorized before expiration time

### DIFF
--- a/.github/workflows/draftnewrelease.yml
+++ b/.github/workflows/draftnewrelease.yml
@@ -22,7 +22,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
       with:
         tag_name: ${{ github.ref }}
-        release_name: Version 3.2.0.0
+        release_name: Version 4.0.0.0
         body: |
           - First Change
           - Second Change

--- a/Api/Api.csproj
+++ b/Api/Api.csproj
@@ -6,7 +6,7 @@
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\KoenZomers.Ring.RecordingDownload.snk</AssemblyOriginatorKeyFile>
     <AssemblyName>KoenZomers.Ring.Api</AssemblyName>
-    <Version>0.5.3.0</Version>
+    <Version>4.0.0.0</Version>
     <Company>Koen Zomers</Company>
     <Authors>Koen Zomers</Authors>
     <Description>API in .NET to communicate with the Ring Doorbell service</Description>
@@ -26,11 +26,4 @@
   <ItemGroup>
     <Compile Include="..\AssemblyInfo.cs" Link="AssemblyInfo.cs" />
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
-  </ItemGroup>
-
-
-
 </Project>

--- a/Api/Api.csproj
+++ b/Api/Api.csproj
@@ -27,6 +27,10 @@
     <Compile Include="..\AssemblyInfo.cs" Link="AssemblyInfo.cs" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
+  </ItemGroup>
+
 
 
 </Project>

--- a/Api/HttpUtility.cs
+++ b/Api/HttpUtility.cs
@@ -101,11 +101,12 @@ namespace KoenZomers.Ring.Api
 
             // Return the response from the server
             var responseFromServer = await response.Content.ReadAsStringAsync();
-            if (!response.IsSuccessStatusCode)
+            if (!response.IsSuccessStatusCode && response.StatusCode == HttpStatusCode.Unauthorized)
             {
                 Console.WriteLine("Response to get contents was not successful.");
                 Console.WriteLine("Response Status: {0}", response.StatusCode);
                 Console.WriteLine("Response: {0}", responseFromServer);
+                response.EnsureSuccessStatusCode(); // throws HttpRequestException that can get caught to re-authenticate.
             }
 
             return responseFromServer;

--- a/Api/HttpUtility.cs
+++ b/Api/HttpUtility.cs
@@ -90,7 +90,7 @@ namespace KoenZomers.Ring.Api
             // Send the request to the webserver
             var response = await _httpClient.SendAsync(request);
 
-            switch(response.StatusCode)
+            switch (response.StatusCode)
             {
                 case HttpStatusCode.TooManyRequests:
                     throw new Exceptions.ThrottledException();
@@ -101,6 +101,13 @@ namespace KoenZomers.Ring.Api
 
             // Return the response from the server
             var responseFromServer = await response.Content.ReadAsStringAsync();
+            if (!response.IsSuccessStatusCode)
+            {
+                Console.WriteLine("Response to get contents was not successful.");
+                Console.WriteLine("Response Status: {0}", response.StatusCode);
+                Console.WriteLine("Response: {0}", responseFromServer);
+            }
+
             return responseFromServer;
         }
 

--- a/Api/Session.cs
+++ b/Api/Session.cs
@@ -125,12 +125,12 @@ namespace KoenZomers.Ring.Api
         /// <exception cref="Exceptions.ThrottledException">Thrown when the web server indicates too many requests have been made (HTTP 429).</exception>
         /// <exception cref="Exceptions.TwoFactorAuthenticationIncorrectException">Thrown when the web server indicates the two-factor code was incorrect (HTTP 400).</exception>
         /// <exception cref="Exceptions.TwoFactorAuthenticationRequiredException">Thrown when the web server indicates two-factor authentication is required (HTTP 412).</exception>
-        public async Task Authenticate(   string operatingSystem = "windows", 
-                                                            string hardwareId = "unspecified", 
-                                                            string appBrand = "ring", 
-                                                            string deviceModel = "unspecified", 
-                                                            string deviceName = "unspecified", 
-                                                            string resolution = "800x600", 
+        public async Task Authenticate(string operatingSystem = "windows",
+                                                            string hardwareId = "unspecified",
+                                                            string appBrand = "ring",
+                                                            string deviceModel = "unspecified",
+                                                            string deviceName = "unspecified",
+                                                            string resolution = "800x600",
                                                             string appVersion = "2.1.8",
                                                             DateTime? appInstallationDate = null,
                                                             string manufacturer = "unspecified",
@@ -173,7 +173,7 @@ namespace KoenZomers.Ring.Api
             }
 
             // Make the Form POST request to request an OAuth Token
-            var oAuthResponse = await _httpUtility.FormPost( RingApiOAuthUrl,
+            var oAuthResponse = await _httpUtility.FormPost(RingApiOAuthUrl,
                                                             oAuthformFields,
                                                             headerFields);
 
@@ -201,7 +201,7 @@ namespace KoenZomers.Ring.Api
             if (!string.IsNullOrEmpty(language)) sessionFormFields.Add("device[metadata][language]", System.Net.WebUtility.UrlEncode(language));
 
             // Make the Form POST request to authenticate
-            var sessionResponse = await _httpUtility.FormPost(   new Uri(RingApiBaseUrl, "session"),
+            var sessionResponse = await _httpUtility.FormPost(new Uri(RingApiBaseUrl, "session"),
                                                                 sessionFormFields,
                                                                 new System.Collections.Specialized.NameValueCollection
                                                                 {
@@ -241,12 +241,16 @@ namespace KoenZomers.Ring.Api
             var oAuthformFields = new Dictionary<string, string>
             {
                 { "grant_type", "refresh_token" },
-                { "refresh_token", refreshToken }
+                { "refresh_token", refreshToken },
+                { "client_id", "ring_official_android" },
+                { "scope", "client" }
             };
-            
+
             // mandatory headers.
             var headerFields = new NameValueCollection()
             {
+                { "2fa-support", "true" },
+                { "2fa-code", "" },
                 { "hardware_id", "unspecified" }
             };
 
@@ -261,7 +265,7 @@ namespace KoenZomers.Ring.Api
                 // Deserialize the JSON result into a typed object
                 OAuthToken = JsonSerializer.Deserialize<OAutToken>(oAuthResponse);
             }
-            catch(System.Net.WebException e)
+            catch (System.Net.WebException e)
             {
                 // If a WebException gets thrown with Unauthorized it means that the refresh token was not valid, throw a custom exception to indicate this
                 if (e.Message.Contains("Unauthorized"))
@@ -307,7 +311,7 @@ namespace KoenZomers.Ring.Api
                 // Refresh token available, try refreshing the session
                 await RefreshSession();
             }
-            
+
             // All good
         }
 
@@ -325,7 +329,7 @@ namespace KoenZomers.Ring.Api
             await EnsureSessionValid();
 
             var response = await _httpUtility.GetContents(new Uri(RingApiBaseUrl, $"ring_devices"), AuthenticationToken);
-            
+
             var devices = JsonSerializer.Deserialize<Devices>(response);
             return devices;
         }
@@ -396,7 +400,7 @@ namespace KoenZomers.Ring.Api
             var downloadRequestUri = new Uri(RingApiBaseUrl, $"dings/{dingId}/share/download?disable_redirect=true");
 
             Entities.DownloadRecording downloadResult = null;
-            for(var downloadAttempt = 1; downloadAttempt < 60; downloadAttempt++)
+            for (var downloadAttempt = 1; downloadAttempt < 60; downloadAttempt++)
             {
                 // Request to download the recording
                 var response = await _httpUtility.GetContents(downloadRequestUri, AuthenticationToken);
@@ -466,7 +470,7 @@ namespace KoenZomers.Ring.Api
 
             using var stream = await GetDoorbotHistoryRecording(dingId);
             using var fileStream = File.Create(saveAs);
-            
+
             await stream.CopyToAsync(fileStream);
         }
 

--- a/Api/Session.cs
+++ b/Api/Session.cs
@@ -302,6 +302,8 @@ namespace KoenZomers.Ring.Api
                     throw new Exceptions.SessionNotAuthenticatedException();
                 }
 
+                Console.WriteLine("Refreshing session, Token expired at {0}", OAuthToken.ExpiresAt);
+
                 // Refresh token available, try refreshing the session
                 await RefreshSession();
             }

--- a/Api/Session.cs
+++ b/Api/Session.cs
@@ -361,11 +361,20 @@ namespace KoenZomers.Ring.Api
 
             do
             {
+
                 // Retrieve a batch with historical items
                 var response = await _httpUtility.GetContents(new Uri(RingApiBaseUrl, $"doorbots/{(doorbotId.HasValue ? $"{doorbotId.Value}/" : "")}history?limit={batchWithItems}{(doorbotHistory.Count == 0 ? "" : "&older_than=" + doorbotHistory.Last().Id)}"), AuthenticationToken);
 
-                // Parse the result
-                doorbotHistory = JsonSerializer.Deserialize<List<DoorbotHistoryEvent>>(response);
+                try
+                {
+                    // Parse the result
+                    doorbotHistory = JsonSerializer.Deserialize<List<DoorbotHistoryEvent>>(response);
+                }
+                catch (JsonException)
+                {
+                    Console.WriteLine("Error parsing JSON: {0}", response);
+                    throw;
+                }
 
                 // Add this next batch to the list with all the results which fit within the provided date span
                 allHistory.AddRange(doorbotHistory.Where(h => h.CreatedAtDateTime.HasValue && h.CreatedAtDateTime.Value >= startDate && (!endDate.HasValue || h.CreatedAtDateTime.Value <= endDate.Value)));

--- a/AssemblyInfo.cs
+++ b/AssemblyInfo.cs
@@ -10,4 +10,4 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("Debug")]
 [assembly: AssemblyCopyright("Koen Zomers")]
 [assembly: AssemblyMetadata("RepositoryUrl", "https://github.com/KoenZomers/RingRecordingDownload")]
-[assembly: AssemblyVersion("3.2.0.0")]
+[assembly: AssemblyVersion("4.0.0.0")]

--- a/ConsoleAppCore/Configuration.cs
+++ b/ConsoleAppCore/Configuration.cs
@@ -61,5 +61,10 @@ namespace KoenZomers.Ring.RecordingDownload
         /// Indicates if a token that may exist from previous sessions should not be used for authentication
         /// </summary>
         public bool IgnoreCachedToken;
+
+        /// <summary>
+        /// The time to wait between calls to the Ring API
+        /// </summary>
+        public TimeSpan TimeBetwenCalls = TimeSpan.Zero;
     }
 }

--- a/ConsoleAppCore/ConsoleAppCore.csproj
+++ b/ConsoleAppCore/ConsoleAppCore.csproj
@@ -7,13 +7,13 @@
     <AssemblyName>RingRecordingDownload</AssemblyName>
     <PackageId>KoenZomers.Ring.RecordingDownload</PackageId>
     <Authors>Koen Zomers</Authors>
-    <Version>3.2.0.0</Version>
+    <Version>4.0.0.0</Version>
     <Product>Ring Recording Download</Product>
     <Description>Allows downloading of recordings from Ring devices from the Ring cloud to your local machine</Description>
     <Copyright>Koen Zomers</Copyright>
     <PackageProjectUrl>https://github.com/KoenZomers/RingRecordingDownload</PackageProjectUrl>
     <PackageTags>Ring</PackageTags>
-    <PackageReleaseNotes>- Upgraded to [Ring API v0.5.3.0](https://github.com/KoenZomers/RingApi#version-history) which fixes some parsing issues</PackageReleaseNotes>
+    <PackageReleaseNotes>- Fixes Session bug that causes the access and refresh token to expire before it should.</PackageReleaseNotes>
 	<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
@@ -43,4 +43,11 @@
     <ProjectReference Include="..\Api\Api.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="App.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>
+

--- a/ConsoleAppCore/Program.cs
+++ b/ConsoleAppCore/Program.cs
@@ -273,7 +273,7 @@ namespace KoenZomers.Ring.RecordingDownload
                 Console.WriteLine("Authenticating using refresh token from previous session");
                 if (session?.OAuthToken != null )
                 {
-                    Console.WriteLine("Session already exists, last token expires(d) at {0}", session.OAuthToken.ExpiresAt);
+                    Console.WriteLine("Session already exists, last token expires(d) at {0}, current time is {1}", session.OAuthToken.ExpiresAt, DateTime.Now);
                 }
 
                 session = await Session.GetSessionByRefreshToken(RefreshToken);
@@ -311,7 +311,8 @@ namespace KoenZomers.Ring.RecordingDownload
             }
 
             // If we have a refresh token, update the config file with it so we don't need to authenticate again next time
-            if (session.OAuthToken != null)
+            // This is only if RefreshToken is null, if not, we're using the refresh token from a previous session
+            if (session.OAuthToken != null && RefreshToken == null)
             {
                 RefreshToken = session.OAuthToken.RefreshToken;
             }

--- a/ConsoleAppCore/Program.cs
+++ b/ConsoleAppCore/Program.cs
@@ -17,7 +17,11 @@ namespace KoenZomers.Ring.RecordingDownload
         /// </summary>
         public static string RefreshToken
         {
-            get { return ConfigurationManager.AppSettings["RefreshToken"]; }
+            get 
+            {
+                Console.WriteLine("Got Refresh token at {0}", DateTime.Now);
+                return ConfigurationManager.AppSettings["RefreshToken"];
+            }
             set
             {
                 var configFile = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
@@ -31,6 +35,7 @@ namespace KoenZomers.Ring.RecordingDownload
                 }
                 configFile.Save(ConfigurationSaveMode.Modified);
                 ConfigurationManager.RefreshSection(configFile.AppSettings.SectionInformation.Name);
+                Console.WriteLine("Refresh token refreshed at {0}", DateTime.Now);
             }
         }
 

--- a/ConsoleAppCore/Program.cs
+++ b/ConsoleAppCore/Program.cs
@@ -234,7 +234,13 @@ namespace KoenZomers.Ring.RecordingDownload
                         catch (HttpRequestException e)
                             when (e.StatusCode == System.Net.HttpStatusCode.Unauthorized)
                         {
-                            await CreateSessionAsync(configuration, session);
+                            int retry = 1;
+                            do
+                            {
+                                await Task.Delay(TimeSpan.FromSeconds(30 * retry));
+                                await CreateSessionAsync(configuration, session);
+                            } while (retry++ < 4);
+                            
                         }
                         catch (System.Net.WebException e)
                         {

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ Console application written in .NET 6 compiled for Windows, Raspberry Pi, Linux 
 
 ## Version History
 
+[4.0.0.0](https://github.com/KoenZomers/RingRecordingDownload/releases/tag/4.0.0.0) - Aug, 07, 2024
+
+- Fixes Session bug that causes the access and refresh token to expire before it should.
+
+
 [3.2.0.0](https://github.com/KoenZomers/RingRecordingDownload/releases/tag/3.2.0.0) - July 26, 2024
 
 - Fixes Token Expiration logic that throws session errors after the token expires.


### PR DESCRIPTION
This PR addresses the issue of auth tokens and refresh tokens expiring or becoming invalid before their expiration time.
The current fix is to call the latest Session API that generates the right token that doesn't expire before it's supposed to.

This PR also addresses the fact that a hardware_id is not being sent to the ring REST API.
This PR also enables users to specify a time between downloads via the --timeBetweenCalls parameter which by default is 0
Also added some verbose logging to be able to debug issues on an easier way.